### PR TITLE
Update kalman readme

### DIFF
--- a/cuthbert/generalised_kalman/README.md
+++ b/cuthbert/generalised_kalman/README.md
@@ -27,3 +27,6 @@ factors).
 This can then be passed to the `build_inference` function to generate an inference object
 which can be used to do filtering (online and offline) and smoothing in a unified interface.
 
+
+`kalman.py` provides offline `filter`, `sampling` and `smoother` functions that all support temporal
+parallelization via the `parallel` argument which defaults to `True`.

--- a/cuthbertlib/kalman/README.md
+++ b/cuthbertlib/kalman/README.md
@@ -6,11 +6,8 @@ This sub-repository provides modular functions for Kalman filtering and smoothin
 
 The core functions are:
 
-- `filter`: Offline Kalman filtering.
 - `predict`: Single prediction step.
 - `filter_update`: Single update step.
-- `sampling`: Generate samples from the smoothing distribution.
-- `smoother`: Offline Rauch-Tung-Striebel smoothing.
 - `smoother_update`: Single Rauch-Tung-Striebel smoothing step.
 
 Together, `predict` and `filter_update` can be used to perform an online filtering step.
@@ -19,12 +16,3 @@ In all cases, we operate on the **square-root form of the covariance matrix**, w
 more numerically stable (in low-precision floating point arithmetic) as the outputs are 
 guaranteed to be positive-definite. This means **we also require input
 covariance matrices to be provided in square-root (Cholesky) form**.
-
-The `sampling` function generates samples from the smoothing distribution without
-requiring the `smoothing` function, it just requires the output from `filter` and the
-parameters of the model.
-
-The offline `filter`, `sampling` and `smoother` functions all support temporal
-parallelization via the `parallel` argument which defaults to `True`.
-
-


### PR DESCRIPTION
Remove references to `filter`, `smoother` and `sampler` from `cuthbertlib/kalman`.