### PR TITLE
fix pre commit indent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,14 +8,14 @@ repos:
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
-  - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.401
-    hooks:
-    - id: pyright
-      additional_dependencies: [jax>=0.4.35, numba>=0.60.0, chex]
-      exclude: ^tests/
-      # Change this to automatically get from pyproject.toml or a requirements.txt?
-      # Seemingly there are good reasons why pre-commit cannot do this https://github.com/pre-commit/pre-commit/issues/730
-      # So we have to duplicate the dependencies here, but suggestions are welcome on how to improve this pyright integration!
+- repo: https://github.com/RobertCraigie/pyright-python
+  rev: v1.1.401
+  hooks:
+  - id: pyright
+    additional_dependencies: [jax>=0.4.35, numba>=0.60.0, chex]
+    exclude: ^tests/
+    # Change this to automatically get from pyproject.toml or a requirements.txt?
+    # Seemingly there are good reasons why pre-commit cannot do this https://github.com/pre-commit/pre-commit/issues/730
+    # So we have to duplicate the dependencies here, but suggestions are welcome on how to improve this pyright integration!
 
 


### PR DESCRIPTION
Sorry, for some reason the previous commit broke continuous integration (even though I was manually able to run the tests on github...). I thought it was a github bug so I pushed.