### PR TITLE
Change log-likelihood to single step

### DIFF
--- a/cuthbertlib/kalman/filtering.py
+++ b/cuthbertlib/kalman/filtering.py
@@ -194,6 +194,6 @@ def filtering_operator(
 
     mu = cho_solve((U1, True), b1)
     t1 = b1 @ mu - (eta2 + mu) @ tmp_2
-    ell = ell1 + ell2 - 0.5 * t1 + 0.5 * jnp.linalg.slogdet(D_inv)[1]
+    ell = ell2 - 0.5 * t1 + 0.5 * jnp.linalg.slogdet(D_inv)[1]
 
     return FilterScanElement(A, b, U, eta, Z, ell)

--- a/tests/cuthbert/gaussian/test_kalman.py
+++ b/tests/cuthbert/gaussian/test_kalman.py
@@ -138,16 +138,18 @@ def test_offline_filter(seed, x_dim, y_dim, num_time_steps):
     P0 = chol_P0 @ chol_P0.T
     Qs = chol_Qs @ chol_Qs.transpose(0, 2, 1)
     Rs = chol_Rs @ chol_Rs.transpose(0, 2, 1)
-    des_means, des_covs, des_ells = std_kalman_filter(
+    des_means, des_covs, des_cumulative_ells = std_kalman_filter(
         m0, P0, Fs, cs, Qs, Hs, ds, Rs, ys
     )
 
     seq_covs = seq_chol_covs @ seq_chol_covs.transpose(0, 2, 1)
     par_covs = par_chol_covs @ par_chol_covs.transpose(0, 2, 1)
+    seq_cumulative_ells = jnp.cumsum(seq_ells)
+    par_cumulative_ells = jnp.cumsum(par_ells)
     chex.assert_trees_all_close(
-        (seq_means, seq_covs, seq_ells),
-        (par_means, par_covs, par_ells),
-        (des_means, des_covs, des_ells),
+        (seq_means, seq_covs, seq_cumulative_ells),
+        (par_means, par_covs, par_cumulative_ells),
+        (des_means, des_covs, des_cumulative_ells),
         rtol=1e-10,
     )
 


### PR DESCRIPTION
I tried the minimal change to get the Kalman filter to output the single-step log-likelihoods but this fails when run in parallel and I'm not sure why.

The code here just does a `vmap` outside of the `associative_scan` so I'm a bit stuck...
https://github.com/EEA-sensors/sqrt-parallel-smoothers/blob/efdb459b89af34d62a4cbfa9780dc8be0442bddc/parsmooth/parallel/_filtering.py#L55

Help?? @Sahel13 @AdrienCorenflos 