### PR TITLE
Fix Non-Local Installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,7 @@ override-dependencies = [
 ]
 
 [tool.setuptools.packages.find]
-where = ["."]
 include = ["cuthbert*", "cuthbertlib*"]
-exclude = ["tests*"]
 
 [project.optional-dependencies]
 tests = [


### PR DESCRIPTION
Addresses #173. This PR makes a small change in the `pyproject.toml` that allows for non-local installation. 

Before, installation does not work correctly. For example, in a fresh colab,
```
!pip install cuthbert
import cuthbert
```
will run into errors. With this fix, 
```
!pip install git+https://github.com/DanWaxman/cuthbert@dw-fix-install
import cuthbert
```
runs fine. I've also run it with the quickstart notebook, and the test suite, neither of which pose any issues.