### PR TITLE
Fix cuthbertlib build

### DIFF
--- a/cuthbertlib/pyproject.toml
+++ b/cuthbertlib/pyproject.toml
@@ -24,5 +24,8 @@ dependencies = [
 path = "_version.py"
 
 [tool.hatch.build.targets.wheel]
-packages = ["."]
-exclude = ["pyproject.toml", "README.md"]
+include = ["**/*.py"]
+exclude = ["pyproject.toml", "README*"]
+
+[tool.hatch.build.targets.wheel.sources]
+"" = "cuthbertlib"


### PR DESCRIPTION
Fixes #193 (hopefully)

I think the problem was that the cuthbertlib code was being installed without a prefix (i.e. just `discrete` rather than `cuthbertlib.discrete`)

Proposed fix based on https://hatch.pypa.io/1.9/config/build/#rewriting-paths

