### PR TITLE
Fix erroneous uv pip -y

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -87,7 +87,7 @@ jobs:
           uv venv
           uv pip install "cuthbertlib==${GITHUB_REF_NAME#v}"
           uv run python -c "import cuthbertlib; import cuthbertlib.discrete"
-          uv pip uninstall -y cuthbertlib
+          uv pip uninstall cuthbertlib
 
       - name: Install cuthbert from PyPI and import
         run: |


### PR DESCRIPTION
The test PyPI Action failed because `pip` recognizes the `-y` argument but `uv pip` does not so I've removed it

I've verified locally it works as expected with `-y`

Action failing: https://github.com/state-space-models/cuthbert/actions/runs/23709332646/job/69066446902