### PR TITLE
Fix to `factorial.discrete` so that it doesn't require custom `init_prepare`

### DIFF
--- a/cuthbert/discrete/filter.py
+++ b/cuthbert/discrete/filter.py
@@ -82,7 +82,7 @@ def init_prepare(
     """
     model_inputs = tree.map(lambda x: jnp.asarray(x), model_inputs)
     init_dist = get_init_dist(model_inputs)
-    N = init_dist.shape[0]
+    N = init_dist.shape[-1]
     f = init_dist * jnp.ones((N, N))
     log_g = jnp.zeros(N)
     return DiscreteFilterState(

--- a/cuthbert/discrete/filter.py
+++ b/cuthbert/discrete/filter.py
@@ -83,8 +83,9 @@ def init_prepare(
     model_inputs = tree.map(lambda x: jnp.asarray(x), model_inputs)
     init_dist = get_init_dist(model_inputs)
     N = init_dist.shape[-1]
-    f = init_dist * jnp.ones((N, N))
-    log_g = jnp.zeros(N)
+    f = init_dist[..., None, :] * jnp.ones((N, N))
+    # repeat init_dist N times onto newly added penultimate axis
+    log_g = jnp.zeros_like(init_dist)
     return DiscreteFilterState(
         elem=filtering.FilterScanElement(f, log_g), model_inputs=model_inputs
     )

--- a/cuthbert/factorial/discrete.py
+++ b/cuthbert/factorial/discrete.py
@@ -190,7 +190,6 @@ def insert(
     new_log_g = jnp.full_like(
         factorial_state.elem.log_g, local_factorial_state.elem.log_g[0, 0]
     )
-    return factorial_state._replace(
+    return local_factorial_state._replace(
         elem=factorial_state.elem._replace(f=new_f, log_g=new_log_g),
-        model_inputs=local_factorial_state.model_inputs,
     )

--- a/tests/cuthbert/factorial/test_discrete.py
+++ b/tests/cuthbert/factorial/test_discrete.py
@@ -9,7 +9,7 @@ from jax import random
 from jax.nn import logsumexp
 
 from cuthbert import factorial
-from cuthbert.discrete.filter import DiscreteFilterState, filter_combine, filter_prepare
+from cuthbert.discrete.filter import build_filter
 from cuthbert.inference import Filter
 from cuthbertlib.discrete.filtering import FilterScanElement
 
@@ -67,16 +67,9 @@ def generate_factorial_hmm(
 
 def build_factorial_discrete_filter(model_params):
     init_dist, trans_matrices, local_obs_lls, factorial_indices = model_params
-    num_states = init_dist.shape[-1]
 
-    def get_init_state(model_inputs, key=None):
-        model_inputs = jnp.asarray(model_inputs)
-        f = jnp.tile(init_dist[:, None, :], (1, num_states, 1))
-        log_g = jnp.zeros((init_dist.shape[0], num_states))
-        return DiscreteFilterState(
-            elem=FilterScanElement(f=f, log_g=log_g),
-            model_inputs=model_inputs,
-        )
+    def get_factorial_init_dist(model_inputs):
+        return init_dist
 
     def get_local_trans_matrix(model_inputs):
         inds = factorial_indices[model_inputs - 1]
@@ -86,15 +79,8 @@ def build_factorial_discrete_filter(model_params):
     def get_local_obs_lls(model_inputs):
         return local_obs_lls[model_inputs - 1]
 
-    filter_obj = Filter(
-        init_prepare=get_init_state,
-        filter_prepare=partial(
-            filter_prepare,
-            get_trans_matrix=get_local_trans_matrix,
-            get_obs_lls=get_local_obs_lls,
-        ),
-        filter_combine=filter_combine,
-        associative=False,
+    filter_obj = build_filter(
+        get_factorial_init_dist, get_local_trans_matrix, get_local_obs_lls
     )
     factorializer = factorial.discrete.build_factorializer(
         lambda model_inputs: factorial_indices[model_inputs - 1]


### PR DESCRIPTION
The current code for `factorial.discrete` is insufficient as it requires overwriting the `init_prepare` in `discrete.filter`. This isn't ideal as `factorial` code is supposed to work with the `cuthbert` filters without modification.

I'm wondering about a more holistic fix. Maybe we can replace `Factorializer` with `FactorialFilter` which still has the `extract`, `join` functions etc but also has `init_prepare`, `filter_prepare`, `filter_combine` which are just inherited from `cuthbert` or wrapped in the case of `init_prepare`. Although this may create too much code clutter. Will think about it some more