### PR TITLE
Add a factorize_initial_state fn

### DIFF
--- a/cuthbert/factorial/filtering.py
+++ b/cuthbert/factorial/filtering.py
@@ -58,6 +58,7 @@ def filter(
     init_factorial_state = filter_obj.init_prepare(
         init_model_input, key=prepare_keys[0]
     )
+    init_factorial_state = factorializer.factorize_initial_state(init_factorial_state)
 
     prep_model_inputs = tree.map(lambda x: x[1:], model_inputs)
 

--- a/cuthbert/factorial/smc.py
+++ b/cuthbert/factorial/smc.py
@@ -17,6 +17,40 @@ GeneralParticleFilterState = TypeVar(
 )
 
 
+class SMCFactorializer(Factorializer):
+    """Factorializer for particle filter states."""
+
+    def factorize_initial_state(
+        self, initial_state: GeneralParticleFilterState
+    ) -> GeneralParticleFilterState:
+        """Convert initial SMC state particles from `(N, F, ...)` to `(F, N, ...)`.
+
+        Generic SMC filters sample initial particles with a leading particle axis.
+        The factorial SMC machinery expects the factor axis to lead instead.
+        Initial weights and particle filter ancestor indices are broadcast from
+        `(N,)` to `(F, N)`, matching the factorial SMC state layout.
+        """
+        particles = tree.map(lambda x: jnp.moveaxis(x, 0, 1), initial_state.particles)
+        n_factors = tree.leaves(particles)[0].shape[0]
+        n_particles = initial_state.log_weights.shape[0]
+
+        new_state = initial_state._replace(
+            particles=particles,
+            log_weights=jnp.broadcast_to(
+                initial_state.log_weights, (n_factors, n_particles)
+            ),
+        )
+
+        if isinstance(initial_state, ParticleFilterState):
+            new_state = new_state._replace(
+                ancestor_indices=jnp.broadcast_to(
+                    initial_state.ancestor_indices, (n_factors, n_particles)
+                )
+            )
+
+        return new_state
+
+
 def build_factorializer(
     get_factorial_indices: GetFactorialIndices,
     resampling_fn: Resampling,
@@ -43,7 +77,7 @@ def build_factorializer(
     Returns:
         Factorializer for SMC states with extract, join, marginalize, and insert.
     """
-    return Factorializer(
+    return SMCFactorializer(
         get_factorial_indices=get_factorial_indices,
         extract=extract,
         join=lambda local_factorial_state: join(local_factorial_state, resampling_fn),

--- a/cuthbert/factorial/types.py
+++ b/cuthbert/factorial/types.py
@@ -160,6 +160,15 @@ class Factorializer(NamedTuple):
     marginalize: Marginalize
     insert: Insert
 
+    def factorize_initial_state(self, initial_state: ArrayTreeLike) -> ArrayTreeLike:
+        """Convert an initial filter state to factorial layout if needed.
+
+        Most inference methods already construct initial states in factorial
+        layout. Inference-specific factorializers can override this when their
+        generic initial state layout differs from the factorial convention.
+        """
+        return initial_state
+
     def extract_and_join(
         self, factorial_state: ArrayTreeLike, model_inputs: ArrayTreeLike
     ) -> ArrayTree:

--- a/cuthbert/smc/marginal_particle_filter.py
+++ b/cuthbert/smc/marginal_particle_filter.py
@@ -34,7 +34,6 @@ def build_filter(
     log_potential: LogPotential,
     n_filter_particles: int,
     resampling_fn: Resampling,
-    init_particle_axis: int = 0,
 ) -> Filter:
     r"""Builds a marginal particle filter object.
 
@@ -47,15 +46,6 @@ def build_filter(
             The resampling function may be decorated with adaptive behaviour
             (using cuthbertlib.resampling.adaptive.adaptive_resampling_decorator)
             before being passed to the filter.
-        init_particle_axis: Axis at which `init_prepare` inserts the particle axis
-            into the initial state. The leading `init_particle_axis` dimensions of
-            `init_sample`'s output are treated as batch (e.g. factor) dimensions and
-            are carried through to `log_weights`. Defaults to `0` (a flat particle
-            set). Set to `1` for factorial filtering, where `init_sample` returns a
-            per-factor sample `(F, ...)` and the factor axis must lead the particle
-            axis. Only the initial state is affected: after the factor axis is
-            collapsed (e.g. by the factorial `join`), the per-step `filter_prepare`/
-            `filter_combine` operate on a flat particle set.
 
     Returns:
         Filter object for the particle filter.
@@ -65,7 +55,6 @@ def build_filter(
             init_prepare,
             init_sample=init_sample,
             n_filter_particles=n_filter_particles,
-            particle_axis=init_particle_axis,
         ),
         filter_prepare=partial(
             filter_prepare,
@@ -87,7 +76,6 @@ def init_prepare(
     init_sample: InitSample,
     n_filter_particles: int,
     key: KeyArray | None = None,
-    particle_axis: int = 0,
 ) -> MarginalParticleFilterState:
     """Prepare the initial state for the marginal particle filter.
 
@@ -96,10 +84,6 @@ def init_prepare(
         init_sample: Function to sample from the initial distribution M_0(x_0).
         n_filter_particles: Number of particles to sample.
         key: JAX random key.
-        particle_axis: Axis at which the particle axis is inserted. The leading
-            `particle_axis` dimensions of `init_sample`'s output are treated as
-            batch (e.g. factor) dimensions and carried through to `log_weights`.
-            Defaults to `0` (a flat particle set).
 
     Returns:
         Initial state for the filter.
@@ -111,18 +95,17 @@ def init_prepare(
     if key is None:
         raise ValueError("A JAX PRNG key must be provided.")
 
-    # Sample, placing the particle axis after any leading batch (factor) dimensions
+    # Sample
     keys = random.split(key, n_filter_particles)
-    particles = jax.vmap(init_sample, (0, None), out_axes=particle_axis)(
-        keys, model_inputs
-    )
+    particles = jax.vmap(init_sample, (0, None))(keys, model_inputs)
 
-    # Weight (uniform), preserving the leading batch dimensions
-    batch_shape = tree.leaves(particles)[0].shape[:particle_axis]
-    log_weights = jnp.zeros((*batch_shape, n_filter_particles))
+    # Weight
+    log_weights = jnp.zeros(n_filter_particles)
 
     # Compute the log normalizing constant
-    log_normalizing_constant = jax.nn.logsumexp(log_weights) - jnp.log(log_weights.size)
+    log_normalizing_constant = jax.nn.logsumexp(log_weights) - jnp.log(
+        n_filter_particles
+    )
 
     return MarginalParticleFilterState(
         key=key,

--- a/cuthbert/smc/particle_filter.py
+++ b/cuthbert/smc/particle_filter.py
@@ -39,7 +39,6 @@ def build_filter(
     log_potential: LogPotential,
     n_filter_particles: int,
     resampling_fn: Resampling,
-    init_particle_axis: int = 0,
 ) -> Filter:
     r"""Builds a particle filter object.
 
@@ -52,15 +51,6 @@ def build_filter(
             The resampling function may be decorated with adaptive behaviour
             (using cuthbertlib.resampling.adaptive.adaptive_resampling_decorator)
             before being passed to the filter.
-        init_particle_axis: Axis at which `init_prepare` inserts the particle axis
-            into the initial state. The leading `init_particle_axis` dimensions of
-            `init_sample`'s output are treated as batch (e.g. factor) dimensions and
-            are carried through to `log_weights` and `ancestor_indices`. Defaults to
-            `0` (a flat particle set). Set to `1` for factorial filtering, where
-            `init_sample` returns a per-factor sample `(F, ...)` and the factor axis
-            must lead the particle axis. Only the initial state is affected: after
-            the factor axis is collapsed (e.g. by the factorial `join`), the per-step
-            `filter_prepare`/`filter_combine` operate on a flat particle set.
 
     Returns:
         Filter object for the particle filter.
@@ -70,7 +60,6 @@ def build_filter(
             init_prepare,
             init_sample=init_sample,
             n_filter_particles=n_filter_particles,
-            particle_axis=init_particle_axis,
         ),
         filter_prepare=partial(
             filter_prepare,
@@ -92,7 +81,6 @@ def init_prepare(
     init_sample: InitSample,
     n_filter_particles: int,
     key: KeyArray | None = None,
-    particle_axis: int = 0,
 ) -> ParticleFilterState:
     """Prepare the initial state for the particle filter.
 
@@ -101,10 +89,6 @@ def init_prepare(
         init_sample: Function to sample from the initial distribution M_0(x_0).
         n_filter_particles: Number of particles to sample.
         key: JAX random key.
-        particle_axis: Axis at which the particle axis is inserted. The leading
-            `particle_axis` dimensions of `init_sample`'s output are treated as
-            batch (e.g. factor) dimensions and carried through to `log_weights`
-            and `ancestor_indices`. Defaults to `0` (a flat particle set).
 
     Returns:
         Initial state for the particle filter.
@@ -116,26 +100,23 @@ def init_prepare(
     if key is None:
         raise ValueError("A JAX PRNG key must be provided.")
 
-    # Sample, placing the particle axis after any leading batch (factor) dimensions
+    # Sample
     keys = random.split(key, n_filter_particles)
-    particles = jax.vmap(init_sample, (0, None), out_axes=particle_axis)(
-        keys, model_inputs
-    )
+    particles = jax.vmap(init_sample, (0, None))(keys, model_inputs)
 
-    # Weight (uniform), preserving the leading batch dimensions
-    batch_shape = tree.leaves(particles)[0].shape[:particle_axis]
-    log_weights = jnp.zeros((*batch_shape, n_filter_particles))
+    # Weight
+    log_weights = jnp.zeros(n_filter_particles)
 
     # Compute the log normalizing constant
-    log_normalizing_constant = jax.nn.logsumexp(log_weights) - jnp.log(log_weights.size)
+    log_normalizing_constant = jax.nn.logsumexp(log_weights) - jnp.log(
+        n_filter_particles
+    )
 
     return ParticleFilterState(
         key=key,
         particles=particles,
         log_weights=log_weights,
-        ancestor_indices=jnp.broadcast_to(
-            jnp.arange(n_filter_particles), (*batch_shape, n_filter_particles)
-        ),
+        ancestor_indices=jnp.arange(n_filter_particles),
         model_inputs=model_inputs,
         log_normalizing_constant=log_normalizing_constant,
     )

--- a/tests/cuthbert/factorial/test_smc.py
+++ b/tests/cuthbert/factorial/test_smc.py
@@ -48,16 +48,12 @@ def build_factorial_smc_filter(
         t = model_inputs.t - 1
         return logpdf(Hs[t] @ state + ds[t], ys[t], chol_Rs[t], nan_support=False)
 
-    # `init_sample` returns a per-factor sample `(F, x_dim)`, so `init_particle_axis=1`
-    # makes the factorial machinery's factor axis lead the particle axis in the
-    # initial state, i.e. particles `(F, N, x_dim)` and weights `(F, N)`.
     filter_obj = build_filter(
         init_sample,
         propagate_sample,
         log_potential,
         n_filter_particles=n_particles,
         resampling_fn=no_resampling.resampling,
-        init_particle_axis=1,
     )
     smc_model_inputs = SMCModelInputs(
         t=jnp.arange(factorial_indices.shape[0] + 1),


### PR DESCRIPTION
@SamDuffield Wdyt of this solution? This is the cleanest I could find where we would neither have to touch the generic SMC code nor have the user call a `build_filter` that was specific to the factorial model.