### PR TITLE
Taylor factorial fix

### DIFF
--- a/cuthbert/gaussian/moments/associative_filter.py
+++ b/cuthbert/gaussian/moments/associative_filter.py
@@ -81,7 +81,9 @@ def filter_prepare(
     model_inputs = tree.map(lambda x: jnp.asarray(x), model_inputs)
     dummy_mean_struct = eval_shape(lambda mi: get_init_params(mi)[0], model_inputs)
     dummy_mean = dummy_tree_like(dummy_mean_struct)
-    dummy_chol_cov = dummy_tree_like(jnp.cov(dummy_mean[..., None]))
+    dummy_chol_cov = dummy_tree_like(
+        jnp.empty(dummy_mean.shape + dummy_mean.shape[-1:], dtype=dummy_mean.dtype)
+    )
 
     dummy_state = LinearizedKalmanFilterState(
         elem=filtering.FilterScanElement(

--- a/cuthbert/gaussian/moments/non_associative_filter.py
+++ b/cuthbert/gaussian/moments/non_associative_filter.py
@@ -69,7 +69,9 @@ def filter_prepare(
     model_inputs = tree.map(lambda x: jnp.asarray(x), model_inputs)
     dummy_mean_struct = eval_shape(lambda mi: get_init_params(mi)[0], model_inputs)
     dummy_mean = dummy_tree_like(dummy_mean_struct)
-    dummy_chol_cov = dummy_tree_like(jnp.cov(dummy_mean[..., None]))
+    dummy_chol_cov = dummy_tree_like(
+        jnp.empty(dummy_mean.shape + dummy_mean.shape[-1:], dtype=dummy_mean.dtype)
+    )
 
     return linearized_kalman_filter_state_dummy_elem(
         mean=dummy_mean,

--- a/cuthbert/gaussian/taylor/associative_filter.py
+++ b/cuthbert/gaussian/taylor/associative_filter.py
@@ -3,7 +3,7 @@
 from jax import eval_shape, tree
 from jax import numpy as jnp
 
-from cuthbert.gaussian.taylor.non_associative_filter import process_observation
+from cuthbert.gaussian.taylor import non_associative_filter
 from cuthbert.gaussian.taylor.types import (
     GetDynamicsLogDensity,
     GetInitLogDensity,
@@ -45,16 +45,11 @@ def init_prepare(
             Contains mean, chol_cov (generalised Cholesky factor of covariance)
             and log_normalizing_constant.
     """
-    model_inputs = tree.map(lambda x: jnp.asarray(x), model_inputs)
-    init_log_density, linearization_point = get_init_log_density(model_inputs)
-
-    _, m0, chol_P0 = linearize_log_density(
-        lambda _, x: init_log_density(x),
-        linearization_point,
-        linearization_point,
-        rtol=rtol,
-        ignore_nan_dims=ignore_nan_dims,
+    non_assoc_init_state = non_associative_filter.init_prepare(
+        model_inputs, get_init_log_density, rtol, ignore_nan_dims, key
     )
+    m0 = non_assoc_init_state.mean
+    chol_P0 = non_assoc_init_state.chol_cov
 
     prior_state = LinearizedKalmanFilterState(
         elem=filtering.FilterScanElement(
@@ -149,7 +144,7 @@ def filter_prepare(
     chol_Q = jnp.where(skip_predict_flag, jnp.zeros_like(chol_Q), chol_Q)
 
     observation_output = get_observation_func(dummy_state, model_inputs)
-    H, d, chol_R, observation = process_observation(
+    H, d, chol_R, observation = non_associative_filter.process_observation(
         observation_output,
         rtol=rtol,
         ignore_nan_dims=ignore_nan_dims,

--- a/cuthbert/gaussian/taylor/associative_filter.py
+++ b/cuthbert/gaussian/taylor/associative_filter.py
@@ -108,7 +108,9 @@ def filter_prepare(
     model_inputs = tree.map(lambda x: jnp.asarray(x), model_inputs)
     dummy_mean_struct = eval_shape(lambda mi: get_init_log_density(mi)[1], model_inputs)
     dummy_mean = dummy_tree_like(dummy_mean_struct)
-    dummy_chol_cov = dummy_tree_like(jnp.cov(dummy_mean[..., None]))
+    dummy_chol_cov = dummy_tree_like(
+        jnp.empty(dummy_mean.shape + dummy_mean.shape[-1:], dtype=dummy_mean.dtype)
+    )
 
     dummy_state = LinearizedKalmanFilterState(
         elem=filtering.FilterScanElement(

--- a/cuthbert/gaussian/taylor/non_associative_filter.py
+++ b/cuthbert/gaussian/taylor/non_associative_filter.py
@@ -1,6 +1,6 @@
 """Implements the non-associative linearized Taylor Kalman filter."""
 
-from jax import eval_shape, tree
+from jax import eval_shape, tree, vmap
 from jax import numpy as jnp
 
 from cuthbert.gaussian.taylor.types import (
@@ -89,13 +89,23 @@ def init_prepare(
     model_inputs = tree.map(lambda x: jnp.asarray(x), model_inputs)
     init_log_density, linearization_point = get_init_log_density(model_inputs)
 
-    _, m0, chol_P0 = linearize_log_density(
-        lambda _, x: init_log_density(x),
-        linearization_point,
-        linearization_point,
-        rtol=rtol,
-        ignore_nan_dims=ignore_nan_dims,
-    )
+    # Handle factorial axis if present
+    lin_point_dim = linearization_point.ndim
+    linearization_point = jnp.atleast_2d(linearization_point)
+
+    _, m0, chol_P0 = vmap(
+        lambda lp: linearize_log_density(
+            lambda _, x: init_log_density(x),
+            lp,
+            lp,
+            rtol=rtol,
+            ignore_nan_dims=ignore_nan_dims,
+        )
+    )(linearization_point)
+
+    if lin_point_dim == 1:
+        m0 = jnp.squeeze(m0, 0)
+        chol_P0 = jnp.squeeze(chol_P0, 0)
 
     prior_state = linearized_kalman_filter_state_dummy_elem(
         mean=m0,

--- a/cuthbert/gaussian/taylor/non_associative_filter.py
+++ b/cuthbert/gaussian/taylor/non_associative_filter.py
@@ -138,7 +138,9 @@ def filter_prepare(
     model_inputs = tree.map(lambda x: jnp.asarray(x), model_inputs)
     dummy_mean_struct = eval_shape(lambda mi: get_init_log_density(mi)[1], model_inputs)
     dummy_mean = dummy_tree_like(dummy_mean_struct)
-    dummy_chol_cov = dummy_tree_like(jnp.cov(dummy_mean[..., None]))
+    dummy_chol_cov = dummy_tree_like(
+        jnp.empty(dummy_mean.shape + dummy_mean.shape[-1:], dtype=dummy_mean.dtype)
+    )
 
     return linearized_kalman_filter_state_dummy_elem(
         mean=dummy_mean,

--- a/tests/cuthbert/gaussian/test_taylor.py
+++ b/tests/cuthbert/gaussian/test_taylor.py
@@ -4,7 +4,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import pytest
-from jax import Array
+from jax import Array, random
 
 from cuthbert import filter, smoother
 from cuthbert.gaussian import taylor
@@ -466,6 +466,52 @@ def test_offline_filter_potential(seed, x_dim, num_time_steps):
         (seq_ass_means, seq_ass_covs, seq_ass_ells),
         (par_ass_means, par_ass_covs, par_ass_ells),
         (des_means, des_covs, des_ells),
+        rtol=1e-5,
+        atol=1e-8,
+    )
+
+
+num_factors = [3, 10]
+common_params_factorial_init = list(itertools.product(seeds, x_dims, num_factors))
+
+
+@pytest.mark.parametrize("seed,x_dim,num_factors", common_params_factorial_init)
+def test_factorial_init(seed, x_dim, num_factors):
+    key = random.PRNGKey(seed)
+    mean_key, chol_cov_key, lin_p_key = random.split(key, 3)
+
+    m0 = random.normal(mean_key, shape=(x_dim,))
+    sqrt_P0 = random.normal(chol_cov_key, shape=(x_dim, x_dim))
+    P0 = sqrt_P0 @ sqrt_P0.T
+    chol_P0 = jnp.linalg.cholesky(P0)
+    lin_p = random.normal(lin_p_key, shape=(num_factors, x_dim))
+
+    def get_init_log_density(model_inputs):
+        def init_log_density(x):
+            return multivariate_normal.logpdf(x, m0, chol_P0)
+
+        return init_log_density, lin_p
+
+    init_state = taylor.non_associative_filter.init_prepare(None, get_init_log_density)
+    init_state_assoc = taylor.associative_filter.init_prepare(
+        None, get_init_log_density
+    )
+
+    factorial_mean = jnp.tile(m0[None], (num_factors, 1))
+    factorial_P0 = jnp.tile(P0[None], (num_factors, 1, 1))
+
+    chex.assert_trees_all_close(
+        (factorial_mean, factorial_P0, 0.0),
+        (
+            init_state.mean,
+            init_state.chol_cov @ init_state.chol_cov.transpose(0, 2, 1),
+            init_state.log_normalizing_constant,
+        ),
+        (
+            init_state_assoc.mean,
+            init_state_assoc.chol_cov @ init_state_assoc.chol_cov.transpose(0, 2, 1),
+            init_state_assoc.log_normalizing_constant,
+        ),
         rtol=1e-5,
         atol=1e-8,
     )


### PR DESCRIPTION
Generalises `gaussian.taylor.init_prepare` to support mean and chol_cov extraction when the linearisation point has a factorial axis.

It's a bit annoying that this support is added in the non-factorial code but I couldn't see a nicer way to do it. It doesn't change the functionality when no factorial dim is provided or add any computation.