### PR TITLE
Add infer state dim arg

### DIFF
--- a/cuthbert/gaussian/taylor/associative_filter.py
+++ b/cuthbert/gaussian/taylor/associative_filter.py
@@ -1,13 +1,14 @@
 """Implements the associative linearized Taylor Kalman filter."""
 
-from jax import eval_shape, tree
 from jax import numpy as jnp
+from jax import tree
 
 from cuthbert.gaussian.taylor import non_associative_filter
 from cuthbert.gaussian.taylor.types import (
     GetDynamicsLogDensity,
     GetInitLogDensity,
     GetObservationFunc,
+    InferStateShape,
 )
 from cuthbert.gaussian.types import LinearizedKalmanFilterState
 from cuthbert.utils import dummy_tree_like
@@ -68,9 +69,9 @@ def init_prepare(
 
 def filter_prepare(
     model_inputs: ArrayTreeLike,
-    get_init_log_density: GetInitLogDensity,
     get_dynamics_log_density: GetDynamicsLogDensity,
     get_observation_func: GetObservationFunc,
+    infer_state_shape: InferStateShape,
     rtol: float | None = None,
     ignore_nan_dims: bool = False,
     key: KeyArray | None = None,
@@ -82,8 +83,6 @@ def filter_prepare(
 
     Args:
         model_inputs: Model inputs.
-        get_init_log_density: Function that returns log density log p(x_0)
-            and linearization point. Only used to infer shape of mean and chol_cov.
         get_dynamics_log_density: Function to get dynamics log density log p(x_t+1 | x_t)
             and linearization points (for the previous and current time points)
             `associative_scan` only supported when `state` is ignored.
@@ -91,6 +90,8 @@ def filter_prepare(
             log density or log potential), linearization point and optional observation
             (not required for log potential functions).
             `associative_scan` only supported when `state` is ignored.
+        infer_state_shape: Function to infer latent shape.
+            Used to infer shape of mean and chol_cov.
         rtol: The relative tolerance for the singular values of precision matrices
             when passed to `symmetric_inv_sqrt` during linearization.
             Cutoff for small singular values; singular values smaller than
@@ -106,9 +107,9 @@ def filter_prepare(
         Prepared state for linearized Taylor Kalman filter.
     """
     model_inputs = tree.map(lambda x: jnp.asarray(x), model_inputs)
-    dummy_mean_struct = eval_shape(lambda mi: get_init_log_density(mi)[1], model_inputs)
-    dummy_mean = dummy_tree_like(dummy_mean_struct)
-    dummy_chol_cov = dummy_tree_like(jnp.cov(dummy_mean[..., None]))
+    latent_shape = infer_state_shape(model_inputs)
+    dummy_mean = dummy_tree_like(jnp.empty(latent_shape))
+    dummy_chol_cov = dummy_tree_like(jnp.empty(latent_shape + latent_shape[-1:]))
 
     dummy_state = LinearizedKalmanFilterState(
         elem=filtering.FilterScanElement(

--- a/cuthbert/gaussian/taylor/filter.py
+++ b/cuthbert/gaussian/taylor/filter.py
@@ -29,19 +29,24 @@ I.e. the linearization points are pre-defined or extracted from model inputs.
 
 from functools import partial
 
+from jax import eval_shape
+
 from cuthbert.gaussian.taylor import associative_filter, non_associative_filter
 from cuthbert.gaussian.taylor.types import (
     GetDynamicsLogDensity,
     GetInitLogDensity,
     GetObservationFunc,
+    InferStateShape,
 )
 from cuthbert.inference import Filter
+from cuthbertlib.types import ArrayTreeLike
 
 
 def build_filter(
     get_init_log_density: GetInitLogDensity,
     get_dynamics_log_density: GetDynamicsLogDensity,
     get_observation_func: GetObservationFunc,
+    infer_state_shape: InferStateShape | None = None,
     associative: bool = False,
     rtol: float | None = None,
     ignore_nan_dims: bool = False,
@@ -67,6 +72,10 @@ def build_filter(
             log density or log potential), linearization point and optional observation
             (not required for log potential functions).
             If `associative` is True, the `state` argument should be ignored.
+        infer_state_shape: Function to infer latent shape.
+            Used to infer shape of mean and chol_cov.
+            Defaults to extracting from the linearization point in `get_init_log_density`
+            using `jax.eval_shape`.
         associative: If True, then the filter is suitable for associative scan, but
             assumes that the `state` is ignored in `get_dynamics_log_density` and
             `get_observation_func`.
@@ -85,6 +94,11 @@ def build_filter(
     Returns:
         Linearized Taylor Kalman filter object.
     """
+    if infer_state_shape is None:
+        infer_state_shape = partial(
+            infer_shape_from_init_log_density, get_init_log_density=get_init_log_density
+        )
+
     if associative:
         return Filter(
             init_prepare=partial(
@@ -95,9 +109,9 @@ def build_filter(
             ),
             filter_prepare=partial(
                 associative_filter.filter_prepare,
-                get_init_log_density=get_init_log_density,
                 get_dynamics_log_density=get_dynamics_log_density,
                 get_observation_func=get_observation_func,
+                infer_state_shape=infer_state_shape,
                 rtol=rtol,
                 ignore_nan_dims=ignore_nan_dims,
             ),
@@ -114,7 +128,7 @@ def build_filter(
             ),
             filter_prepare=partial(
                 non_associative_filter.filter_prepare,
-                get_init_log_density=get_init_log_density,
+                infer_state_shape=infer_state_shape,
             ),
             filter_combine=partial(
                 non_associative_filter.filter_combine,
@@ -125,3 +139,20 @@ def build_filter(
             ),
             associative=False,
         )
+
+
+def infer_shape_from_init_log_density(
+    model_inputs: ArrayTreeLike, get_init_log_density
+) -> tuple[int]:
+    """Infer latent shape from `get_init_log_density`'s lineatization point.
+
+    Args:
+        model_inputs: Model inputs.
+        get_init_log_density: Function to get log density log p(x_0)
+            and linearization point.
+
+    Returns:
+        Tuple of integer dimensions. Typically (x_dim,)
+    """
+    dummy_mean_struct = eval_shape(lambda mi: get_init_log_density(mi)[1], model_inputs)
+    return dummy_mean_struct.shape

--- a/cuthbert/gaussian/taylor/filter.py
+++ b/cuthbert/gaussian/taylor/filter.py
@@ -143,7 +143,7 @@ def build_filter(
 
 def infer_shape_from_init_log_density(
     model_inputs: ArrayTreeLike, get_init_log_density
-) -> tuple[int]:
+) -> tuple[int, ...]:
     """Infer latent shape from `get_init_log_density`'s lineatization point.
 
     Args:

--- a/cuthbert/gaussian/taylor/non_associative_filter.py
+++ b/cuthbert/gaussian/taylor/non_associative_filter.py
@@ -1,12 +1,13 @@
 """Implements the non-associative linearized Taylor Kalman filter."""
 
-from jax import eval_shape, tree, vmap
 from jax import numpy as jnp
+from jax import tree, vmap
 
 from cuthbert.gaussian.taylor.types import (
     GetDynamicsLogDensity,
     GetInitLogDensity,
     GetObservationFunc,
+    InferStateShape,
     LogConditionalDensity,
     LogPotential,
 )
@@ -119,7 +120,7 @@ def init_prepare(
 
 def filter_prepare(
     model_inputs: ArrayTreeLike,
-    get_init_log_density: GetInitLogDensity,
+    infer_state_shape: InferStateShape,
     key: KeyArray | None = None,
 ) -> LinearizedKalmanFilterState:
     """Prepare a state for a linearized Taylor Kalman filter step.
@@ -128,17 +129,17 @@ def filter_prepare(
 
     Args:
         model_inputs: Model inputs.
-        get_init_log_density: Function that returns log density log p(x_0)
-            and linearization point. Only used to infer shape of mean and chol_cov.
+        infer_state_shape: Function to infer latent shape.
+            Used to infer shape of mean and chol_cov.
         key: JAX random key - not used.
 
     Returns:
         Prepared state for linearized Taylor Kalman filter.
     """
     model_inputs = tree.map(lambda x: jnp.asarray(x), model_inputs)
-    dummy_mean_struct = eval_shape(lambda mi: get_init_log_density(mi)[1], model_inputs)
-    dummy_mean = dummy_tree_like(dummy_mean_struct)
-    dummy_chol_cov = dummy_tree_like(jnp.cov(dummy_mean[..., None]))
+    latent_shape = infer_state_shape(model_inputs)
+    dummy_mean = dummy_tree_like(jnp.empty(latent_shape))
+    dummy_chol_cov = dummy_tree_like(jnp.empty(latent_shape + latent_shape[-1:]))
 
     return linearized_kalman_filter_state_dummy_elem(
         mean=dummy_mean,

--- a/cuthbert/gaussian/taylor/types.py
+++ b/cuthbert/gaussian/taylor/types.py
@@ -84,3 +84,18 @@ class GetObservationFunc(Protocol):
                 point.
         """
         ...
+
+
+class InferStateShape(Protocol):
+    """Protocol for inferring the latent state shape from model_inputs."""
+
+    def __call__(self, model_inputs: ArrayTreeLike) -> tuple[int]:
+        """Extract shape of latent state (e.g mean) from model_inputs.
+
+        Args:
+            model_inputs: Model inputs.
+
+        Returns:
+            Tuple integer shapes. Typically (x_dim,)
+        """
+        ...

--- a/cuthbert/gaussian/taylor/types.py
+++ b/cuthbert/gaussian/taylor/types.py
@@ -89,7 +89,7 @@ class GetObservationFunc(Protocol):
 class InferStateShape(Protocol):
     """Protocol for inferring the latent state shape from model_inputs."""
 
-    def __call__(self, model_inputs: ArrayTreeLike) -> tuple[int]:
+    def __call__(self, model_inputs: ArrayTreeLike) -> tuple[int, ...]:
         """Extract shape of latent state (e.g mean) from model_inputs.
 
         Args:


### PR DESCRIPTION
Proposed fix for handling factorial case when linearization points are of different shape for init and dynamics. 
Allows the user to provide an optional override for shape inference in `filter_prepare` (default in `build_filter` is to use the init linearization point).

@Sahel13 what do you think? If we go with this I think we'd need to do something similar for `moments`

(Tests all passed locally for me)