### PR TITLE
Generalize taylor `GetInitLogDensity` for factorial models

### DIFF
--- a/cuthbert/gaussian/taylor/non_associative_filter.py
+++ b/cuthbert/gaussian/taylor/non_associative_filter.py
@@ -90,6 +90,7 @@ def init_prepare(
     model_inputs = tree.map(lambda x: jnp.asarray(x), model_inputs)
     init_log_density, linearization_point = get_init_log_density(model_inputs)
 
+    # Handle factorial axis if present
     linearization_shape = linearization_point.shape
     flat_linearization_point = linearization_point.reshape(-1)
 

--- a/cuthbert/gaussian/taylor/non_associative_filter.py
+++ b/cuthbert/gaussian/taylor/non_associative_filter.py
@@ -1,6 +1,6 @@
 """Implements the non-associative linearized Taylor Kalman filter."""
 
-from jax import eval_shape, tree, vmap
+from jax import eval_shape, tree
 from jax import numpy as jnp
 
 from cuthbert.gaussian.taylor.types import (
@@ -14,6 +14,7 @@ from cuthbert.gaussian.types import LinearizedKalmanFilterState
 from cuthbert.gaussian.utils import linearized_kalman_filter_state_dummy_elem
 from cuthbert.utils import dummy_tree_like
 from cuthbertlib.kalman import filtering
+from cuthbertlib.linalg import block_marginal_sqrt_cov
 from cuthbertlib.linearize import linearize_log_density, linearize_taylor
 from cuthbertlib.types import Array, ArrayTreeLike, KeyArray
 
@@ -89,23 +90,23 @@ def init_prepare(
     model_inputs = tree.map(lambda x: jnp.asarray(x), model_inputs)
     init_log_density, linearization_point = get_init_log_density(model_inputs)
 
-    # Handle factorial axis if present
-    lin_point_dim = linearization_point.ndim
-    linearization_point = jnp.atleast_2d(linearization_point)
+    linearization_shape = linearization_point.shape
+    flat_linearization_point = linearization_point.reshape(-1)
 
-    _, m0, chol_P0 = vmap(
-        lambda lp: linearize_log_density(
-            lambda _, x: init_log_density(x),
-            lp,
-            lp,
-            rtol=rtol,
-            ignore_nan_dims=ignore_nan_dims,
-        )
-    )(linearization_point)
+    def flat_init_log_density(_, flat_x):
+        return init_log_density(flat_x.reshape(linearization_shape))
 
-    if lin_point_dim == 1:
-        m0 = jnp.squeeze(m0, 0)
-        chol_P0 = jnp.squeeze(chol_P0, 0)
+    _, m0, chol_P0 = linearize_log_density(
+        flat_init_log_density,
+        flat_linearization_point,
+        flat_linearization_point,
+        rtol=rtol,
+        ignore_nan_dims=ignore_nan_dims,
+    )
+    m0 = m0.reshape(linearization_shape)
+
+    if linearization_point.ndim > 1:
+        chol_P0 = block_marginal_sqrt_cov(chol_P0, linearization_point.shape[-1])
 
     prior_state = linearized_kalman_filter_state_dummy_elem(
         mean=m0,

--- a/cuthbert/gaussian/taylor/types.py
+++ b/cuthbert/gaussian/taylor/types.py
@@ -21,6 +21,9 @@ class GetInitLogDensity(Protocol):
     def __call__(self, model_inputs: ArrayTreeLike) -> tuple[LogDensity, Array]:
         """Get the initial log density and initial linearization point.
 
+        If the state-space model is a factorial model, this should return the
+        sum of the log densities for each factor.
+
         Args:
             model_inputs: Model inputs.
 

--- a/tests/cuthbert/factorial/test_taylor.py
+++ b/tests/cuthbert/factorial/test_taylor.py
@@ -1,16 +1,13 @@
 import jax
 import jax.numpy as jnp
 
-import cuthbert
 from cuthbert import factorial
-from cuthbert.factorial.utils import serial_to_single_factor
 from cuthbert.gaussian import taylor
-from cuthbertlib.linalg import block_marginal_sqrt_cov
 from cuthbertlib.stats import multivariate_normal
 from tests.cuthbert.factorial.gaussian_utils import generate_factorial_kalman_model
 
 
-def test_factorial_taylor_filter_and_smoother_jit():
+def test_factorial_taylor_filter_jit():
     x_dim = 2
     y_dim = 1
     num_factors = 3
@@ -96,63 +93,3 @@ def test_factorial_taylor_filter_and_smoother_jit():
         x_dim,
     )
     assert local_filter_states.log_normalizing_constant.shape == (num_time_steps,)
-
-    smoother_factorial_index = 0
-    single_factor_filter_states = serial_to_single_factor(
-        factorializer.extract,
-        local_filter_states,
-        factorial_indices,
-        smoother_factorial_index,
-        init_factorial_tree=init_state,
-    )
-
-    selected = factorial_indices == smoother_factorial_index
-    selected_local_indices = jnp.argmax(selected, axis=1)
-    selected_times = jnp.flatnonzero(jnp.any(selected, axis=1), size=2)
-    selected_indices = selected_local_indices[selected_times]
-    projected_Fs = Fs.reshape(
-        num_time_steps,
-        num_factors_local,
-        x_dim,
-        num_factors_local,
-        x_dim,
-    )[selected_times, selected_indices, :, selected_indices, :]
-    projected_cs = cs.reshape(num_time_steps, num_factors_local, x_dim)[
-        selected_times, selected_indices
-    ]
-    marginal_chol_Qs = jax.vmap(lambda chol_Q: block_marginal_sqrt_cov(chol_Q, x_dim))(
-        chol_Qs
-    )
-    projected_chol_Qs = marginal_chol_Qs[selected_times, selected_indices]
-
-    def get_projected_dynamics_log_density(state, model_inputs):
-        F = projected_Fs[model_inputs - 1]
-        c = projected_cs[model_inputs - 1]
-        chol_Q = projected_chol_Qs[model_inputs - 1]
-
-        def dynamics_log_density(x_prev, x):
-            return multivariate_normal.logpdf(x, F @ x_prev + c, chol_Q)
-
-        return dynamics_log_density, state.mean, F @ state.mean + c
-
-    smoother_obj = taylor.build_smoother(get_projected_dynamics_log_density)
-    smoother_model_inputs = jnp.arange(len(projected_Fs) + 1)
-    run_smoother = jax.jit(
-        lambda filter_states, model_inputs: cuthbert.smoother(
-            smoother_obj,
-            filter_states,
-            model_inputs,
-        )
-    )
-    smoother_states = run_smoother(
-        single_factor_filter_states,
-        smoother_model_inputs,
-    )
-
-    num_smoother_states = len(projected_Fs) + 1
-    assert smoother_states.mean.shape == (num_smoother_states, x_dim)
-    assert smoother_states.chol_cov.shape == (
-        num_smoother_states,
-        x_dim,
-        x_dim,
-    )

--- a/tests/cuthbert/factorial/test_taylor.py
+++ b/tests/cuthbert/factorial/test_taylor.py
@@ -1,0 +1,158 @@
+import jax
+import jax.numpy as jnp
+
+import cuthbert
+from cuthbert import factorial
+from cuthbert.factorial.utils import serial_to_single_factor
+from cuthbert.gaussian import taylor
+from cuthbertlib.linalg import block_marginal_sqrt_cov
+from cuthbertlib.stats import multivariate_normal
+from tests.cuthbert.factorial.gaussian_utils import generate_factorial_kalman_model
+
+
+def test_factorial_taylor_filter_and_smoother_jit():
+    x_dim = 2
+    y_dim = 1
+    num_factors = 3
+    num_factors_local = 2
+    num_time_steps = 3
+
+    model_params = generate_factorial_kalman_model(
+        seed=0,
+        x_dim=x_dim,
+        y_dim=y_dim,
+        num_factors=num_factors,
+        num_factors_local=num_factors_local,
+        num_time_steps=num_time_steps,
+    )
+    m0s, chol_P0s, Fs, cs, chol_Qs, Hs, ds, chol_Rs, ys, _ = model_params
+    factorial_indices = jnp.array([[0, 1], [1, 2], [0, 2]])
+
+    # Users have to specify a initial log density that acts on the full factorial state.
+    def get_init_log_density(model_inputs):
+        def _init_log_density(x):
+            return jnp.sum(jax.vmap(multivariate_normal.logpdf)(x, m0s, chol_P0s))
+
+        return _init_log_density, jnp.zeros((num_factors, x_dim))
+
+    def get_dynamics_log_density(state, model_inputs):
+        F = Fs[model_inputs - 1]
+        c = cs[model_inputs - 1]
+        chol_Q = chol_Qs[model_inputs - 1]
+
+        def dynamics_log_density(x_prev, x):
+            return multivariate_normal.logpdf(x, F @ x_prev + c, chol_Q)
+
+        return dynamics_log_density, state.mean, F @ state.mean + c
+
+    def get_observation_log_density(state, model_inputs):
+        H = Hs[model_inputs - 1]
+        d = ds[model_inputs - 1]
+        chol_R = chol_Rs[model_inputs - 1]
+
+        def observation_log_density(x, y):
+            return multivariate_normal.logpdf(y, H @ x + d, chol_R)
+
+        return observation_log_density, state.mean, ys[model_inputs - 1]
+
+    filter_obj = taylor.build_filter(
+        get_init_log_density,
+        get_dynamics_log_density,
+        get_observation_log_density,
+    )
+    factorializer = factorial.gaussian.build_factorializer(
+        lambda model_inputs: factorial_indices[model_inputs - 1]
+    )
+    filter_model_inputs = jnp.arange(num_time_steps + 1)
+
+    run_filter = jax.jit(
+        lambda model_inputs: factorial.filter(
+            filter_obj,
+            factorializer,
+            model_inputs,
+            output_factorial=False,
+        )
+    )
+    init_state, local_filter_states = run_filter(filter_model_inputs)
+
+    assert init_state.mean.shape == (num_factors, x_dim)
+    assert init_state.chol_cov.shape == (num_factors, x_dim, x_dim)
+    assert jnp.allclose(init_state.mean, m0s, rtol=1e-4, atol=1e-4)
+    assert jnp.allclose(
+        init_state.chol_cov @ init_state.chol_cov.transpose(0, 2, 1),
+        chol_P0s @ chol_P0s.transpose(0, 2, 1),
+        rtol=1e-4,
+        atol=1e-4,
+    )
+    assert local_filter_states.mean.shape == (
+        num_time_steps,
+        num_factors_local,
+        x_dim,
+    )
+    assert local_filter_states.chol_cov.shape == (
+        num_time_steps,
+        num_factors_local,
+        x_dim,
+        x_dim,
+    )
+    assert local_filter_states.log_normalizing_constant.shape == (num_time_steps,)
+
+    smoother_factorial_index = 0
+    single_factor_filter_states = serial_to_single_factor(
+        factorializer.extract,
+        local_filter_states,
+        factorial_indices,
+        smoother_factorial_index,
+        init_factorial_tree=init_state,
+    )
+
+    selected = factorial_indices == smoother_factorial_index
+    selected_local_indices = jnp.argmax(selected, axis=1)
+    selected_times = jnp.flatnonzero(jnp.any(selected, axis=1), size=2)
+    selected_indices = selected_local_indices[selected_times]
+    projected_Fs = Fs.reshape(
+        num_time_steps,
+        num_factors_local,
+        x_dim,
+        num_factors_local,
+        x_dim,
+    )[selected_times, selected_indices, :, selected_indices, :]
+    projected_cs = cs.reshape(num_time_steps, num_factors_local, x_dim)[
+        selected_times, selected_indices
+    ]
+    marginal_chol_Qs = jax.vmap(lambda chol_Q: block_marginal_sqrt_cov(chol_Q, x_dim))(
+        chol_Qs
+    )
+    projected_chol_Qs = marginal_chol_Qs[selected_times, selected_indices]
+
+    def get_projected_dynamics_log_density(state, model_inputs):
+        F = projected_Fs[model_inputs - 1]
+        c = projected_cs[model_inputs - 1]
+        chol_Q = projected_chol_Qs[model_inputs - 1]
+
+        def dynamics_log_density(x_prev, x):
+            return multivariate_normal.logpdf(x, F @ x_prev + c, chol_Q)
+
+        return dynamics_log_density, state.mean, F @ state.mean + c
+
+    smoother_obj = taylor.build_smoother(get_projected_dynamics_log_density)
+    smoother_model_inputs = jnp.arange(len(projected_Fs) + 1)
+    run_smoother = jax.jit(
+        lambda filter_states, model_inputs: cuthbert.smoother(
+            smoother_obj,
+            filter_states,
+            model_inputs,
+        )
+    )
+    smoother_states = run_smoother(
+        single_factor_filter_states,
+        smoother_model_inputs,
+    )
+
+    num_smoother_states = len(projected_Fs) + 1
+    assert smoother_states.mean.shape == (num_smoother_states, x_dim)
+    assert smoother_states.chol_cov.shape == (
+        num_smoother_states,
+        x_dim,
+        x_dim,
+    )

--- a/tests/cuthbert/factorial/test_taylor.py
+++ b/tests/cuthbert/factorial/test_taylor.py
@@ -62,15 +62,10 @@ def test_factorial_taylor_filter_jit():
     )
     filter_model_inputs = jnp.arange(num_time_steps + 1)
 
-    run_filter = jax.jit(
-        lambda model_inputs: factorial.filter(
-            filter_obj,
-            factorializer,
-            model_inputs,
-            output_factorial=False,
-        )
-    )
-    init_state, local_filter_states = run_filter(filter_model_inputs)
+    init_state, local_filter_states = jax.jit(
+        factorial.filter,
+        static_argnames=("filter_obj", "factorializer", "output_factorial"),
+    )(filter_obj, factorializer, filter_model_inputs, output_factorial=False)
 
     assert init_state.mean.shape == (num_factors, x_dim)
     assert init_state.chol_cov.shape == (num_factors, x_dim, x_dim)

--- a/tests/cuthbert/gaussian/test_taylor.py
+++ b/tests/cuthbert/gaussian/test_taylor.py
@@ -488,7 +488,10 @@ def test_factorial_init(seed, x_dim, num_factors):
 
     def get_init_log_density(model_inputs):
         def init_log_density(x):
-            return multivariate_normal.logpdf(x, m0, chol_P0)
+            factor_log_densities = jax.vmap(
+                lambda factor_x: multivariate_normal.logpdf(factor_x, m0, chol_P0)
+            )(x)
+            return jnp.sum(factor_log_densities)
 
         return init_log_density, lin_p
 


### PR DESCRIPTION
The change made in #252 makes the assumption that the prior distribution for all factors is the same. This PR removes that.